### PR TITLE
[WIP] Windows clang support for VS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang|AppleClang")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-return-mismatch")
 endif()
 
-if (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang|AppleClang")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-implicit-function-declaration")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-return-type")
 endif()

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -1,0 +1,22 @@
+﻿{
+  "configurations": [
+    {
+      "name": "x64-Clang-Debug",
+      "generator": "Ninja",
+      "configurationType": "Debug",
+      "buildRoot": "${projectDir}\\out\\build\\${name}",
+      "installRoot": "${projectDir}\\out\\install\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": "",
+      "inheritEnvironments": [ "clang_cl_x64_x64" ],
+      "variables": [
+        {
+          "name": "SDL2_PATH",
+          "value": "${projectDir}\\vclib\\SDL2-2.28.5",
+          "type": "STRING"
+        }
+      ]
+    }
+  ]
+}

--- a/src/pc/psxsdk/libapi.c
+++ b/src/pc/psxsdk/libapi.c
@@ -27,11 +27,9 @@ long TestEvent(unsigned long event) {
     return 1;
 }
 
-#if !defined(_MSC_VER) && !defined(__MINGW32__)
 // needs to be disabled on Windows as it overlaps with the kernel32 API:
 // https://learn.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-entercriticalsection
 void EnterCriticalSection(void) { NOT_IMPLEMENTED; }
-#endif
 
 void ExitCriticalSection(void) { NOT_IMPLEMENTED; }
 


### PR DESCRIPTION
If someone on Windows wants to try this out and see if it's working for them too

- Install clang support for VS from VS Installer:
![image](https://github.com/user-attachments/assets/afaa07b8-7635-4eb0-bbbf-0a49a58ad17d)

- Open folder in VS
- Map SDL2 path for build (I've made this `..\vclib\SDL2-2.28.5` from SOTN project root by default
- Build project
- Copy SDL2.dll into `[projroot]\out\build\x64-Clang-Debug\`
- In VS, open Debug -> Debug and Launch Settings for Sound

Use following debug configuration
```
{
  "version": "0.2.1",
  "defaults": {},
  "configurations": [
    {
      "type": "default",
      "project": "CMakeLists.txt",
      "projectTarget": "Sound.exe",
      "name": "Sound.exe",
      "currentDir": "${projectDir}",
      "args": [
        "\u0022${projectDir}\\disks\\sotn.us.bin\u0022"
      ]
    }
  ]
}
```

castlevania.us.bin should be Track 1 of your dumped bin/cue.
